### PR TITLE
Add talk proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-proposal-template.md
+++ b/.github/ISSUE_TEMPLATE/talk-proposal-template.md
@@ -1,0 +1,27 @@
+---
+name: Talk Proposal Template
+about: Talk Proposal Template
+title: 'talk- '
+labels: ''
+assignees: ''
+
+---
+
+## Talk Name
+...
+
+## Description
+...
+
+Things covered in talk
+
+* something
+* something
+
+## Prerequisite
+* [ ] HTML
+* [ ] JavaScript
+
+⌛️ Talk Duration - **30 mins**
+👤 Name - 
+📍 Location - Delhi / Bangalore / Pune / Mumbai / Jaipur


### PR DESCRIPTION
For writing a proposal whatever guidelines the author needs to follow will show up in the Issue creation editor. This would be much easier than going back and forth between Readme and Create Issue page.